### PR TITLE
v1.8.1, libecpint fixes

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,12 +16,8 @@ if [ "$(uname)" == "Linux" ]; then
     cp external_src/psi4PluginCachelinux.cmake t_plug0
 fi
 
-export ECPINT=ON
 if [[ "${target_platform}" == "osx-arm64" ]]; then
     export LAPACK_LIBRARIES="${PREFIX}/lib/liblapack${SHLIB_EXT};${PREFIX}/lib/libblas${SHLIB_EXT}"
-    if [[ "${PY_VER}" != "3.10" ]]; then
-        export ECPINT=OFF
-    fi
 else
     export LAPACK_LIBRARIES="${PREFIX}/lib/libmkl_rt${SHLIB_EXT}"
 fi
@@ -55,8 +51,8 @@ ${BUILD_PREFIX}/bin/cmake ${CMAKE_ARGS} ${ARCH_ARGS} \
   -D psi4_SKIP_ENABLE_Fortran=ON \
   -D ENABLE_dkh=ON \
   -D CMAKE_INSIST_FIND_PACKAGE_dkh=ON \
-  -D ENABLE_ecpint=${ECPINT} \
-  -D CMAKE_INSIST_FIND_PACKAGE_ecpint=${ECPINT} \
+  -D ENABLE_ecpint=ON \
+  -D CMAKE_INSIST_FIND_PACKAGE_ecpint=ON \
   -D ENABLE_PCMSolver=ON \
   -D CMAKE_INSIST_FIND_PACKAGE_PCMSolver=ON \
   -D ENABLE_OPENMP=ON \

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ source:
     folder: external_src                                                      # [unix]
 
 build:
-  number: 0
+  number: 1
   #skip: true  # [py != 310]
   script_env:
     - PSI4_PRETEND_VERSIONLONG={{ version }}+{{ commit }}
@@ -117,8 +117,7 @@ requirements:
     - pydantic =1
     # qc opt'l, build-time
     - dkh
-    - libecpint                              # [x86_64 or py==310]
-    # libecpint is unavailable on osx-arm64 and py != 310 until https://github.com/conda-forge/libecpint-feedstock/pull/8 merged
+    - libecpint
     - pcmsolver
   run:
     - llvm-openmp                            # [unix]


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

The fix I made in [conda-forge/libecpint#8](https://github.com/conda-forge/libecpint-feedstock/pull/8) to make the osx-arm64 builds python-independent used the newest pugixml packages, and pugixml in the meantime had converted from static to dynamic libraries, so the libecpint packages were missing the xml runtime dependency, and psi4 noticed and complained at runtime. [conda-forge/libecpint#12](https://github.com/conda-forge/libecpint-feedstock/pull/12) fixed that up. So now psi4 can be rebuild and all arch/py can have a working ecpint.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* ~Reset the build number to `0` (if the version changed)~
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
