### PR TITLE
fix rerender on feedstock

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,7 +5,7 @@ if [ "$(uname)" == "Darwin" ]; then
     # avoid "error: 'value' is unavailable: introduced in macOS 10.13"
     CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
 
-    cp psi4PluginCacheosx.cmake t_plug0
+    cp "${RECIPE_DIR}/src/psi4PluginCacheosx.cmake" t_plug0
 fi
 if [ "$(uname)" == "Linux" ]; then
     ARCH_ARGS=""
@@ -15,7 +15,7 @@ if [ "$(uname)" == "Linux" ]; then
     git rev-parse --is-inside-work-tree
     git rev-parse --show-toplevel
 
-    cp psi4PluginCachelinux.cmake t_plug0
+    cp "${RECIPE_DIR}/src/psi4PluginCachelinux.cmake" t_plug0
 fi
 
 if [[ "${target_platform}" == "osx-arm64" ]]; then

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,7 +5,7 @@ if [ "$(uname)" == "Darwin" ]; then
     # avoid "error: 'value' is unavailable: introduced in macOS 10.13"
     CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
 
-    cp external_src/psi4PluginCacheosx.cmake t_plug0
+    cp psi4PluginCacheosx.cmake t_plug0
 fi
 if [ "$(uname)" == "Linux" ]; then
     ARCH_ARGS=""
@@ -15,7 +15,7 @@ if [ "$(uname)" == "Linux" ]; then
     git rev-parse --is-inside-work-tree
     git rev-parse --show-toplevel
 
-    cp external_src/psi4PluginCachelinux.cmake t_plug0
+    cp psi4PluginCachelinux.cmake t_plug0
 fi
 
 if [[ "${target_platform}" == "osx-arm64" ]]; then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,9 +17,12 @@ source:
   #- url: https://github.com/{{ name }}/{{ name }}/archive/{{ commit }}.tar.gz
   - url: https://github.com/{{ name }}/{{ name }}/archive/v{{ version }}.tar.gz
     sha256: {{ sha256 }}
+  # below only used by unix
+  - path: ./src                                                               # [unix]
+    folder: external_src                                                      # [unix]
 
 build:
-  number: 4
+  number: 5
   # skip: true  # [py != 310]
   script_env:
     - PSI4_PRETEND_VERSIONLONG={{ version }}+{{ commit }}
@@ -80,7 +83,7 @@ requirements:
     - {{ stdlib("c") }}
     - {{ compiler("c") }}
     - {{ compiler("cxx") }}
-    - cmake 3.29                                       # 3.30 failing for intel mac
+    - cmake 3.29.*                                     # 3.30 failing for intel mac
     - make                                   # [unix]
     - ninja                                  # [win]
     - llvm-openmp                            # [unix]
@@ -162,7 +165,7 @@ test:
     - pymdi
     # plugin testing
     - {{ compiler('cxx') }}                                              # [unix]
-    - cmake 3.29                                                         # [unix]
+    - cmake 3.29.*                                                       # [unix]
     - make                                                               # [unix]
     - pybind11                                                           # [unix]
     - eigen                                                              # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,9 +17,7 @@ source:
   #- url: https://github.com/{{ name }}/{{ name }}/archive/{{ commit }}.tar.gz
   - url: https://github.com/{{ name }}/{{ name }}/archive/v{{ version }}.tar.gz
     sha256: {{ sha256 }}
-  # below only used by unix but selector breaks web rerender
   - path: ./src
-    folder: external_src
 
 build:
   number: 5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,6 @@ source:
   #- url: https://github.com/{{ name }}/{{ name }}/archive/{{ commit }}.tar.gz
   - url: https://github.com/{{ name }}/{{ name }}/archive/v{{ version }}.tar.gz
     sha256: {{ sha256 }}
-  - path: ./src
 
 build:
   number: 5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,9 +17,9 @@ source:
   #- url: https://github.com/{{ name }}/{{ name }}/archive/{{ commit }}.tar.gz
   - url: https://github.com/{{ name }}/{{ name }}/archive/v{{ version }}.tar.gz
     sha256: {{ sha256 }}
-  # below only used by unix
-  - path: ./src                                                               # [unix]
-    folder: external_src                                                      # [unix]
+  # below only used by unix but selector breaks web rerender
+  - path: ./src
+    folder: external_src
 
 build:
   number: 5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,6 @@ source:
   #- url: https://github.com/{{ name }}/{{ name }}/archive/{{ commit }}.tar.gz
   - url: https://github.com/{{ name }}/{{ name }}/archive/v{{ version }}.tar.gz
     sha256: {{ sha256 }}
-  - path: ./src                                                               # [unix]
-    folder: external_src                                                      # [unix]
 
 build:
   number: 4


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] ~Reset the build number to `0` (if the version changed)~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
- completely removing the secondary src section that was once used to pull extra stuff into windows and some extra recipe files into linux. the win was removed in the last couple months. the unix is now replaced by RECIPE_DIR and it seems to be picked up and installed. if anyone's reading this, (1) the pre-PR way worked perfectly fine in conda-build, (2) the rerender worked fine locally on linux (it was only the web service rerender that was broken here at feedstock and on numpy2 migration), (3) removing the `[unix]` selector to `source/src` didn't fix the rerender.