### PR TITLE
v1.10.2, runtime dep updates

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -51,7 +51,7 @@ jobs:
       osx_arm64_python3.10.____cpython:
         CONFIG: osx_arm64_python3.10.____cpython
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: quick
         pagefile_size: 0
@@ -61,7 +61,7 @@ jobs:
       osx_arm64_python3.11.____cpython:
         CONFIG: osx_arm64_python3.11.____cpython
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: quick
         pagefile_size: 0
@@ -71,7 +71,7 @@ jobs:
       osx_arm64_python3.12.____cpython:
         CONFIG: osx_arm64_python3.12.____cpython
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: quick
         pagefile_size: 0
@@ -81,7 +81,7 @@ jobs:
       osx_arm64_python3.13.____cp313:
         CONFIG: osx_arm64_python3.13.____cp313
         UPLOAD_PACKAGES: 'True'
-        VMIMAGE: macOS-15
+        VMIMAGE: macOS-15-arm64
         build_workspace_dir: ~/miniforge3/conda-bld
         free_disk_space: quick
         pagefile_size: 0

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -28,7 +28,7 @@ jobs:
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
             docker_run_args: 
-            free_disk_space: skip
+            free_disk_space: quick
             os: ubuntu
             pagefile_size: 0
             resize_partitions: False
@@ -40,7 +40,7 @@ jobs:
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
             docker_run_args: 
-            free_disk_space: skip
+            free_disk_space: quick
             os: ubuntu
             pagefile_size: 0
             resize_partitions: False
@@ -52,7 +52,7 @@ jobs:
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
             docker_run_args: 
-            free_disk_space: skip
+            free_disk_space: quick
             os: ubuntu
             pagefile_size: 0
             resize_partitions: False
@@ -64,7 +64,7 @@ jobs:
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
             docker_run_args: 
-            free_disk_space: skip
+            free_disk_space: quick
             os: ubuntu
             pagefile_size: 0
             resize_partitions: False
@@ -76,7 +76,7 @@ jobs:
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
             docker_run_args: 
-            free_disk_space: skip
+            free_disk_space: quick
             os: ubuntu
             pagefile_size: 0
             resize_partitions: False
@@ -88,7 +88,7 @@ jobs:
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
             docker_run_args: 
-            free_disk_space: skip
+            free_disk_space: quick
             os: ubuntu
             pagefile_size: 0
             resize_partitions: False
@@ -100,7 +100,7 @@ jobs:
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
             docker_run_args: 
-            free_disk_space: skip
+            free_disk_space: quick
             os: ubuntu
             pagefile_size: 0
             resize_partitions: False
@@ -112,7 +112,7 @@ jobs:
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts
             docker_run_args: 
-            free_disk_space: skip
+            free_disk_space: quick
             os: ubuntu
             pagefile_size: 0
             resize_partitions: False
@@ -122,6 +122,14 @@ jobs:
 
     - name: Checkout code
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Manage disk space
+      env:
+        FREE_DISK_SPACE: ${{ matrix.free_disk_space }}
+        OS: ${{ matrix.os }}
+      shell: bash
+      run: |
+        .scripts/free_disk_space.sh "${FREE_DISK_SPACE}"
     - name: Configure binfmt_misc
       if: matrix.os == 'ubuntu'
       shell: bash

--- a/README.md
+++ b/README.md
@@ -73,6 +73,34 @@ Current build status
                 </a>
               </td>
             </tr><tr>
+              <td>osx_arm64_python3.10.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19309&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/psi4-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_python3.10.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_python3.11.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19309&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/psi4-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_python3.11.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_python3.12.____cpython</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19309&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/psi4-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_python3.12.____cpython" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>osx_arm64_python3.13.____cp313</td>
+              <td>
+                <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19309&branchName=main">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/psi4-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_python3.13.____cp313" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
               <td>win_64_python3.10.____cpython</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=19309&branchName=main">

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,11 +1,11 @@
 azure:
-  free_disk_space: true
   settings_linux:
     swapfile_size: 10GiB
   settings_win:
     variables:
       SET_PAGEFILE: 'True'
 workflow_settings:
+  free_disk_space: 'quick'
   store_build_artifacts:
     - platform: [linux_64, win_64]
       value: false
@@ -17,8 +17,6 @@ workflow_settings:
       value: C:\\Miniforge
 build_platform:
   linux_aarch64: linux_64
-  linux_ppc64le: linux_64
-  osx_arm64: osx_64
 conda_build:
   error_overlinking: true
 conda_forge_output_validation: true
@@ -27,5 +25,5 @@ github:
   tooling_branch_name: main
 provider:
   linux_aarch64: default
-  linux_ppc64le: default
+  osx_arm64: default
 test: native_and_emulated

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [ppc64le]
   # skip: true  # [ppc64le or py != 312]
   # skip: true  # [not (win and py==313)]
@@ -126,11 +126,10 @@ requirements:
     - python
     - scipy
     # qc
-    #- {{ pin_compatible('optking', max_pin='x') }}
-    - {{ pin_compatible('optking', max_pin='x.x') }}
+    - {{ pin_compatible('optking', lower_bound='0.4.2', upper_bound='0.8.0') }}
     - {{ pin_compatible('qcelemental', lower_bound='0.29', upper_bound='0.70') }}
     - {{ pin_compatible('qcengine', lower_bound='0.31', upper_bound='0.70') }}
-    - {{ pin_compatible('qcmanybody', max_pin='x') }}
+    - {{ pin_compatible('qcmanybody', lower_bound='0.5.1', upper_bound='0.10.0') }}
     - {{ pin_compatible('libint', exact=True) }}    # ABI-wise x is good, but practically to fend off breakage from AM bumps, impose x.x or exact
   run_constrained:
     - pytest >=7.0.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,6 @@ source:
 
 build:
   number: 1
-  skip: true  # [ppc64le]
   # skip: true  # [ppc64le or py != 312]
   # skip: true  # [not (win and py==313)]
   script_env:
@@ -78,7 +77,7 @@ requirements:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - pybind11                               # [build_platform != target_platform]
-    - numpy <2.5.0                           # [build_platform != target_platform]
+    - numpy                                  # [build_platform != target_platform]
     - qcelemental                            # [build_platform != target_platform]  # version detection w/cross+poetry
     - {{ stdlib("c") }}
     - {{ compiler("c") }}
@@ -95,7 +94,7 @@ requirements:
     - mkl-devel                              # [x86_64]
     - libblas * *netlib                      # [not x86_64]
     - liblapack * *netlib                    # [not x86_64]
-    - numpy <2.5.0
+    - numpy
     - pybind11
     - pybind11-abi
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -78,7 +78,7 @@ requirements:
     - python                                 # [build_platform != target_platform]
     - cross-python_{{ target_platform }}     # [build_platform != target_platform]
     - pybind11                               # [build_platform != target_platform]
-    - numpy                                  # [build_platform != target_platform]
+    - numpy <2.5.0                           # [build_platform != target_platform]
     - qcelemental                            # [build_platform != target_platform]  # version detection w/cross+poetry
     - {{ stdlib("c") }}
     - {{ compiler("c") }}
@@ -95,7 +95,7 @@ requirements:
     - mkl-devel                              # [x86_64]
     - libblas * *netlib                      # [not x86_64]
     - liblapack * *netlib                    # [not x86_64]
-    - numpy
+    - numpy <2.5.0
     - pybind11
     - pybind11-abi
     - python


### PR DESCRIPTION
Relax optking and qcmb constraints so it can solver with qcel 0.30. Also rebuild with qcel 0.50.3 so it can work with numpy 2.5. Adjust conda_forge.yml like I did in #61 so build native osx-arm64 .

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* ~Reset the build number to `0` (if the version changed)~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
